### PR TITLE
add cargo config to docker

### DIFF
--- a/cargo-config.toml
+++ b/cargo-config.toml
@@ -1,0 +1,2 @@
+[net]
+git-fetch-with-cli = true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
         volumes:
             - ./journali-api:/usr/src/api
             - ./.cache/cargo:/usr/local/cargo/registry
+            - ./cargo-config.toml:/usr/local/cargo/config
         working_dir: /usr/src/api
         entrypoint: cargo
         command: run server


### PR DESCRIPTION
Adds a cargo configuration file to docker to fix `failed to truncate pack file`.
See https://github.com/rust-lang/cargo/issues/6652